### PR TITLE
Prefix names to stop clashing

### DIFF
--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -21,12 +21,12 @@ esphome:
 
 switch:
 - platform: template
-  name: "Buzzer Enabled"
+  name: "${upper_devicename} Buzzer Enabled"
   id: buzzer_enabled
   icon: mdi:volume-high
   optimistic: true
 - platform: template
-  name: "LED enabled"
+  name: "${upper_devicename} LED enabled"
   id: led_enabled
   optimistic: true
 
@@ -115,5 +115,4 @@ light:
   rgb_order: GRB
   id: activity_led
   restore_mode: ALWAYS_OFF
-  name: "Activity LED"
   internal: true


### PR DESCRIPTION
Entities from ESPHome get an `entity_id` with the `name` field so it is always a good idea to prefix them with the device name.

Also the `activity_led` is marked as `internal: true` so there is no need for a name