### PR TITLE
Expose LED to Home Assistant

### DIFF
--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -71,7 +71,7 @@ spi:
 pn532:
   cs_pin: D3
   update_interval: 2s
-  
+
   # What happens when a tag is read
   on_tag:
     then:
@@ -79,19 +79,6 @@ pn532:
         event: esphome.tag_scanned
         data:
           tag_id: !lambda 'return x;'
-    - if:
-        condition:
-          switch.is_on: led_enabled
-        then:
-        - light.turn_on:
-            id: activity_led
-            brightness: 100%
-            red: 0%
-            green: 100%
-            blue: 0%
-        - delay: 500ms
-        - light.turn_off:
-            id: activity_led
     - if:
         condition:
           switch.is_on: buzzer_enabled
@@ -107,9 +94,7 @@ pn532:
             red: 0%
             green: 100%
             blue: 0%
-        - delay: 500ms
-        - light.turn_off:
-            id: activity_led
+            flash_length: 500ms
 
 # Define the buzzer output
 output:
@@ -130,5 +115,5 @@ light:
   num_leds: 1
   rgb_order: GRB
   id: activity_led
+  name: "${upper_devicename} LED"
   restore_mode: ALWAYS_OFF
-  internal: true


### PR DESCRIPTION
Also flash the led on a tag scan
When using a `flash_length` the light will go back to the previous state after that duration.
Also removed a `turn_on` duplicate from a merge (Unless this was intended?)