### PR TITLE
Flash script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Gitignore settings for ESPHome
+# This is an example and may include too much for your use-case.
+# You can modify this file to suit your needs.
+/.esphome/
+**/.pioenvs/
+**/.piolibdeps/
+**/lib/
+**/src/
+**/platformio.ini
+/secrets.yaml

--- a/scripts/flash
+++ b/scripts/flash
@@ -8,13 +8,11 @@ mac=${mac//:/}
 
 echo "MAC ending: ${mac}"
 
-sed -i "s/devicename: tagreader/devicename: tagreader_${mac}/" tagreader.yaml
-sed -i "s/upper_devicename: TagReader/upper_devicename: TagReader ${mac}/" tagreader.yaml
+devicename="tagreader_${mac}"
+upper_devicename="TagReader ${mac}"
 
-esphome tagreader.yaml compile
-esphome tagreader.yaml upload
-
-sed -i "s/.${mac}//" tagreader.yaml
+esphome --substitution devicename "${devicename}" --substitution upper_devicename "${upper_devicename}" tagreader.yaml compile
+esphome --substitution devicename "${devicename}" --substitution upper_devicename "${upper_devicename}" tagreader.yaml upload
 
 rm -rf tagreader_${mac}
 

--- a/scripts/flash
+++ b/scripts/flash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Getting mac address from device..."
+mac=$(esptool.py read_mac | grep -m 1 'MAC:' | grep -o '.\{8\}$' )
+mac=${mac//:/}
+
+echo "MAC ending: ${mac}"
+
+sed -i "s/devicename: tagreader/devicename: tagreader_${mac}/" tagreader.yaml
+sed -i "s/upper_devicename: TagReader/upper_devicename: TagReader ${mac}/" tagreader.yaml
+
+esphome tagreader.yaml compile
+esphome tagreader.yaml upload
+
+sed -i "s/.${mac}//" tagreader.yaml
+
+rm -rf tagreader_${mac}
+
+echo "Done tagreader_${mac}"

--- a/scripts/flash
+++ b/scripts/flash
@@ -9,10 +9,10 @@ mac=${mac//:/}
 echo "MAC ending: ${mac}"
 
 devicename="tagreader_${mac}"
-upper_devicename="TagReader ${mac}"
+friendly_name="TagReader ${mac}"
 
-esphome --substitution devicename "${devicename}" --substitution upper_devicename "${upper_devicename}" tagreader.yaml compile
-esphome --substitution devicename "${devicename}" --substitution upper_devicename "${upper_devicename}" tagreader.yaml upload
+esphome --substitution devicename "${devicename}" --substitution friendly_name "${friendly_name}" tagreader.yaml compile
+esphome --substitution devicename "${devicename}" --substitution friendly_name "${friendly_name}" tagreader.yaml upload
 
 rm -rf tagreader_${mac}
 

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -11,7 +11,7 @@ captive_portal:
 
 substitutions:
   devicename: tagreader
-  upper_devicename: TagReader
+  friendly_name: TagReader
 
 esphome:
   name: $devicename
@@ -30,12 +30,12 @@ esphome:
 # Define switches to control LED and buzzer from HA
 switch:
 - platform: template
-  name: "${upper_devicename} Buzzer Enabled"
+  name: "${friendly_name} Buzzer Enabled"
   id: buzzer_enabled
   icon: mdi:volume-high
   optimistic: true
 - platform: template
-  name: "${upper_devicename} LED enabled"
+  name: "${friendly_name} LED enabled"
   id: led_enabled
   icon: mdi:alarm-light-outline
   optimistic: true
@@ -120,5 +120,5 @@ light:
   num_leds: 1
   rgb_order: GRB
   id: activity_led
-  name: "${upper_devicename} LED"
+  name: "${friendly_name} LED"
   restore_mode: ALWAYS_OFF


### PR DESCRIPTION
This flash script can be used to easily flash multiple devices with a single `tagreader.yaml` file and keeps them unique.
It does this by:
1. Reading the devices mac address from the plugged in device
2. Appends the last 6 characters of the mac address to the `devicename` and `upper_devicename` using cli [substitutions](https://esphome.io/guides/cli.html#substitution-option)
3. Compiles the firmware 
4. Uploads the firmware
6. Cleans up the build folder


Also renames `upper_devicename` to `friendly_name`