### PR TITLE
[IMPORTANT] The Frizz Schematic is wrong, read on....

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,17 @@ Scanned tags can be managed from the tags interface in Home Assistant. You can f
 ## 
 
 TODO
+
+# RFID module wiring
+
+D1 Mini officals may work following the Fritz Schematics above, but the clones seem to require the following:
+
+| D1 Mini | PN532 |
+|---------|-------|
+| D0      | SCK   |
+| D1      | MISO  |
+| D2      | MOSI  |
+| D3      | SS    |
+| 5V      | VCC   |
+| G       | GND   |
+

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -68,7 +68,7 @@ ota:
 
 # Enable SPI interface
 spi:
-  clk_pin: TX
+  clk_pin: D0
   miso_pin: D1
   mosi_pin: D2
 


### PR DESCRIPTION
This corrects the issue with boards like the A-Z Delivery D1 Mini clones, but the fritz schematic in the docs is still incorrect, I don't have the software to correct it.

Using the TX pin may also cause issues with programming, as the logger will be outputting to this by default AFAIK. I had to disconnect the TX pin to flash this after soldering the first time.