### PR TITLE
Change to use the new tag_scanned action in ESPHome 1.15.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ Also make sure that you have set the switches on the PN532 to the following:
 
 This enables the PN532 module to communicate with the D1 over SPI, and is required for the modules to work together!
 
+To flash the reader firmware to your D1 Mini you point ESPHome at [tagreader.yaml](https://github.com/adonno/tagreader/blob/master/tagreader.yaml).  
+**The tag reader requires ESPHome 1.15.2 or later.**
 
-To flash the reader firmware to your D1 Mini you point ESPHome at [tagreader.yaml](https://github.com/adonno/tagreader/blob/master/tagreader.yaml). If you're new to ESPHome, we recommend that you use the [ESPHome Home Assistant add-on](https://esphome.io/guides/getting_started_hassio.html).
+If you're new to ESPHome, we recommend that you use the [ESPHome Home Assistant add-on](https://esphome.io/guides/getting_started_hassio.html).
 
 ![Open Case](https://raw.githubusercontent.com/adonno/tagreader/master/docs/open-case.jpg)
 

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -80,10 +80,7 @@ pn532:
   # What happens when a tag is read
   on_tag:
     then:
-    - homeassistant.event:
-        event: esphome.tag_scanned
-        data:
-          tag_id: !lambda 'return x;'
+    - homeassistant.tag_scanned: !lambda 'return x;'
     - if:
         condition:
           switch.is_on: buzzer_enabled


### PR DESCRIPTION
This is a **breaking change** as it changes the required ESPHome version to be at least [1.15.2](https://github.com/esphome/esphome/releases/tag/v1.15.2)

[ESPHome docs](https://esphome.io/components/api.html#homeassistant-tag-scanned-action)
[PN532 docs](https://esphome.io/components/binary_sensor/pn532.html?highlight=pn532#on-tag)