### PR TITLE
NDEF formatted tag reading

### DIFF
--- a/includes/ndef.h
+++ b/includes/ndef.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "esphome.h"
+
+#include "NfcAdapter.h"
+#include "PN532/PN532.h"
+#include "PN532_SPI/PN532_SPI.h"
+
+static const char *TAG = "ndef_tag_reader";
+
+static const std::string TAG_PREFIX = "home-assistant.io/tag/";
+
+class NDEFTagReader : public PollingComponent, public TextSensor {
+ public:
+  NDEFTagReader() : PollingComponent(1000) {}
+  void setup() override {
+    this->pn532spi_ = new PN532_SPI(SPI, 0);
+    this->nfc_ = new NfcAdapter(*this->pn532spi_);
+    this->nfc_->begin();
+  }
+
+  void update() override {
+    if (this->nfc_->tagPresent()) {
+      ESP_LOGD(TAG, "Tag Found!");
+      NfcTag tag = this->nfc_->read();
+
+      if (tag.hasNdefMessage()) {
+        ESP_LOGD(TAG, "Tag has NDEF");
+        NdefMessage message = tag.getNdefMessage();
+        int recordCount = message.getRecordCount();
+        ESP_LOGD(TAG, "Tag has %d records", recordCount);
+        for (int i = 0; i < recordCount; i++) {
+          NdefRecord record = message.getRecord(i);
+
+          ESP_LOGD(TAG, "Record %d", (i+1));
+          ESP_LOGD(TAG, "Type: %s", record.getType().c_str());
+
+          int payloadLength = record.getPayloadLength();
+          byte payload[payloadLength];
+          record.getPayload(payload);
+
+          std::string payloadAsString;
+          for (int c = 0; c < payloadLength; c++) {
+            payloadAsString += (char)payload[c];
+          }
+          ESP_LOGD(TAG, "Payload: %s", payloadAsString.c_str());
+          size_t pos = payloadAsString.find(TAG_PREFIX);
+          if (pos != std::string::npos) {
+            this->publish_state(payloadAsString.substr(pos + TAG_PREFIX.length()));
+            this->set_timeout("tag_clear", 1000, [this]() { this->publish_state(""); });
+          }
+        }
+      } else {
+        ESP_LOGD(TAG, "No NDEF");
+      }
+    }
+  }
+ protected:
+  PN532_SPI *pn532spi_;
+  NfcAdapter *nfc_;
+};

--- a/includes/ndef.h
+++ b/includes/ndef.h
@@ -20,38 +20,42 @@ class NDEFTagReader : public PollingComponent, public TextSensor {
   }
 
   void update() override {
-    if (this->nfc_->tagPresent()) {
-      ESP_LOGD(TAG, "Tag Found!");
-      NfcTag tag = this->nfc_->read();
+    if (!this->nfc_->tagPresent()) {
+      return;
+    }
 
-      if (tag.hasNdefMessage()) {
-        ESP_LOGD(TAG, "Tag has NDEF");
-        NdefMessage message = tag.getNdefMessage();
-        int recordCount = message.getRecordCount();
-        ESP_LOGD(TAG, "Tag has %d records", recordCount);
-        for (int i = 0; i < recordCount; i++) {
-          NdefRecord record = message.getRecord(i);
+    ESP_LOGD(TAG, "Tag Found!");
+    NfcTag tag = this->nfc_->read();
 
-          ESP_LOGD(TAG, "Record %d", (i+1));
-          ESP_LOGD(TAG, "Type: %s", record.getType().c_str());
+    if (!tag.hasNdefMessage()) {
+      ESP_LOGD(TAG, "No NDEF");
+      // TODO handle non-ndef tags by just sending the uid
+      return;
+    }
 
-          int payloadLength = record.getPayloadLength();
-          byte payload[payloadLength];
-          record.getPayload(payload);
+    ESP_LOGD(TAG, "Tag has NDEF");
+    NdefMessage message = tag.getNdefMessage();
+    int recordCount = message.getRecordCount();
+    ESP_LOGD(TAG, "Tag has %d records", recordCount);
+    for (int i = 0; i < recordCount; i++) {
+      NdefRecord record = message.getRecord(i);
 
-          std::string payloadAsString;
-          for (int c = 0; c < payloadLength; c++) {
-            payloadAsString += (char)payload[c];
-          }
-          ESP_LOGD(TAG, "Payload: %s", payloadAsString.c_str());
-          size_t pos = payloadAsString.find(TAG_PREFIX);
-          if (pos != std::string::npos) {
-            this->publish_state(payloadAsString.substr(pos + TAG_PREFIX.length()));
-            this->set_timeout("tag_clear", 1000, [this]() { this->publish_state(""); });
-          }
-        }
-      } else {
-        ESP_LOGD(TAG, "No NDEF");
+      ESP_LOGD(TAG, "Record %d", (i+1));
+      ESP_LOGD(TAG, "Type: %s", record.getType().c_str());
+
+      int payloadLength = record.getPayloadLength();
+      byte payload[payloadLength];
+      record.getPayload(payload);
+
+      std::string payloadAsString;
+      for (int c = 0; c < payloadLength; c++) {
+        payloadAsString += (char)payload[c];
+      }
+      ESP_LOGD(TAG, "Payload: %s", payloadAsString.c_str());
+      size_t pos = payloadAsString.find(TAG_PREFIX);
+      if (pos != std::string::npos) {
+        this->publish_state(payloadAsString.substr(pos + TAG_PREFIX.length()));
+        this->set_timeout("tag_clear", 1000, [this]() { this->publish_state(""); });
       }
     }
   }

--- a/includes/ndef.h
+++ b/includes/ndef.h
@@ -29,7 +29,10 @@ class NDEFTagReader : public PollingComponent, public TextSensor {
 
     if (!tag.hasNdefMessage()) {
       ESP_LOGD(TAG, "No NDEF");
-      // TODO handle non-ndef tags by just sending the uid
+      std::string uid(tag.getUidString().c_str());
+      ESP_LOGD(TAG, "Tag UID: %s", uid.c_str());
+      this->publish_state(uid);
+      this->set_timeout("tag_clear", 1000, [this]() { this->publish_state(""); });
       return;
     }
 

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -1,119 +1,133 @@
-# Insert your SSID and Your PWD after inital setup
-wifi:
-  networks:
-#    - ssid: !secret wifi_ssid          # Uncomment this line (remove # at beginning of line) and enter your details in secrets.yaml file!
-#      password: !secret wifi_password  # Uncomment this line (remove # at beginning of line) and enter your details in secrets.yaml file!
-  ap:
-    ssid: ${devicename}
+ap:
+  ssid: ${devicename}
 
 # Enable the captive portal for inital WiFi setup
 captive_portal:
 
 substitutions:
-  devicename: tagreader
-  friendly_name: TagReader
+devicename: tagreader
+friendly_name: TagReader
 
 esphome:
-  name: $devicename
-  platform: ESP8266
-  board: d1_mini
+name: $devicename
+platform: ESP8266
+board: d1_mini
+includes:
+  - rfidreader/src/test.h
 
 # If buzzer is enabled, notify on api connection success
-  on_boot:
-    priority: -10
-    then:
-    - wait_until:
-        api.connected:
-    - logger.log: API is connected!
-    - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
+on_boot:
+  priority: -10
+  then:
+  - wait_until:
+      api.connected:
+  - logger.log: API is connected!
+  # - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
 
 # Define switches to control LED and buzzer from HA
 switch:
 - platform: template
-  name: "${friendly_name} Buzzer Enabled"
-  id: buzzer_enabled
-  icon: mdi:volume-high
-  optimistic: true
+name: "${friendly_name} Buzzer Enabled"
+id: buzzer_enabled
+icon: mdi:volume-high
+optimistic: true
 - platform: template
-  name: "${friendly_name} LED enabled"
-  id: led_enabled
-  icon: mdi:alarm-light-outline
-  optimistic: true
+name: "${friendly_name} LED enabled"
+id: led_enabled
+icon: mdi:alarm-light-outline
+optimistic: true
 
 # Enable logging
 logger:
-  baud_rate: 9600
+# baud_rate: 9600
 
 # Enable Home Assistant API
 api:
-  services:
-  - service: rfidreader_tag_ok
-    then:
-    - rtttl.play: "beep:d=16,o=5,b=100:b"
+services:
+- service: rfidreader_tag_ok
+  then:
+  - rtttl.play: "beep:d=16,o=5,b=100:b"
 
-  - service: rfidreader_tag_ko
-    then:
-    - rtttl.play: "beep:d=8,o=5,b=100:b"
+- service: rfidreader_tag_ko
+  then:
+  - rtttl.play: "beep:d=8,o=5,b=100:b"
 
-  - service: play_rtttl
-    variables:
-      song_str: string
-    then:
-    - rtttl.play: !lambda 'return song_str;'
+- service: play_rtttl
+  variables:
+    song_str: string
+  then:
+  - rtttl.play: !lambda 'return song_str;'
 
 # Enable OTA upgrade
 ota:
 
 # Enable SPI interface
 spi:
-  clk_pin: D0
-  miso_pin: D1
-  mosi_pin: D2
+clk_pin: D5
+miso_pin: D6
+mosi_pin: D7
 
 # Configure the PN532 module
 pn532:
-  cs_pin: D3
-  update_interval: 2s
+cs_pin: D3
+update_interval: 2s
 
-  # What happens when a tag is read
-  on_tag:
-    then:
-    - homeassistant.tag_scanned: !lambda 'return x;'
-    - if:
-        condition:
-          switch.is_on: buzzer_enabled
-        then:
-        - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
-    - if:
-        condition:
-          switch.is_on: led_enabled
-        then:
-        - light.turn_on:
-            id: activity_led
-            brightness: 100%
-            red: 0%
-            green: 100%
-            blue: 0%
-            flash_length: 500ms
+# What happens when a tag is read
+on_tag:
+  then:
+  - homeassistant.event:
+      event: esphome.tag_scanned
+      data:
+        tag_id: !lambda 'return x;'
+  - if:
+      condition:
+        switch.is_on: buzzer_enabled
+      then:
+      - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
+  - if:
+      condition:
+        switch.is_on: led_enabled
+      then:
+      - light.turn_on:
+          id: activity_led
+          brightness: 100%
+          red: 0%
+          green: 100%
+          blue: 0%
+          flash_length: 500ms
 
 # Define the buzzer output
 output:
 - platform: esp8266_pwm
-  pin: D8
-  id: buzzer
+pin: D0
+id: buzzer
 
 # Define buzzer as output for RTTTL
 rtttl:
-  output: buzzer
+output: buzzer
 
 # Configure LED
 light:
 - platform: fastled_clockless
-  chipset: WS2812
-  pin: D7
-  default_transition_length: 10ms
-  num_leds: 1
-  rgb_order: GRB
-  id: activity_led
-  name: "${friendly_name} LED"
-  restore_mode: ALWAYS_OFF
+chipset: WS2812
+pin: D2
+default_transition_length: 10ms
+num_leds: 1
+rgb_order: GRB
+id: activity_led
+name: "${friendly_name} LED"
+restore_mode: ALWAYS_OFF
+
+text_sensor:
+
+
+
+- platform: custom
+lambda: |-
+  auto my_custom_sensor = new MyCustomTextSensor();
+  App.register_component(my_custom_sensor);
+  return {my_custom_sensor};
+
+text_sensors:
+  name: "My Custom Text Sensor"
+  # update_interval 5s

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -3,134 +3,128 @@ wifi:
   networks:
 #    - ssid: !secret wifi_ssid          # Uncomment this line (remove # at beginning of line) and enter your details in secrets.yaml file!
 #      password: !secret wifi_password  # Uncomment this line (remove # at beginning of line) and enter your details in secrets.yaml file!
-ap:
-  ssid: ${devicename}
+  ap:
+    ssid: ${devicename}
 
 # Enable the captive portal for inital WiFi setup
 captive_portal:
 
 substitutions:
-devicename: tagreader
-friendly_name: TagReader
+  devicename: tagreader
+  friendly_name: TagReader
 
 esphome:
-name: $devicename
-platform: ESP8266
-board: d1_mini
-includes:
-  - rfidreader/src/test.h
+  name: $devicename
+  platform: ESP8266
+  board: d1_mini
+  includes: 
+    - rfidreader/src/test.h
 
 # If buzzer is enabled, notify on api connection success
-on_boot:
-  priority: -10
-  then:
-  - wait_until:
-      api.connected:
-  - logger.log: API is connected!
-  # - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
+  on_boot:
+    priority: -10
+    then:
+    - wait_until:
+        api.connected:
+    - logger.log: API is connected!
+    - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
 
 # Define switches to control LED and buzzer from HA
 switch:
 - platform: template
-name: "${friendly_name} Buzzer Enabled"
-id: buzzer_enabled
-icon: mdi:volume-high
-optimistic: true
+  name: "${friendly_name} Buzzer Enabled"
+  id: buzzer_enabled
+  icon: mdi:volume-high
+  optimistic: true
 - platform: template
-name: "${friendly_name} LED enabled"
-id: led_enabled
-icon: mdi:alarm-light-outline
-optimistic: true
+  name: "${friendly_name} LED enabled"
+  id: led_enabled
+  icon: mdi:alarm-light-outline
+  optimistic: true
 
 # Enable logging
 logger:
-# baud_rate: 9600
+  baud_rate: 9600
 
 # Enable Home Assistant API
 api:
-services:
-- service: rfidreader_tag_ok
-  then:
-  - rtttl.play: "beep:d=16,o=5,b=100:b"
+  services:
+  - service: rfidreader_tag_ok
+    then:
+    - rtttl.play: "beep:d=16,o=5,b=100:b"
 
-- service: rfidreader_tag_ko
-  then:
-  - rtttl.play: "beep:d=8,o=5,b=100:b"
+  - service: rfidreader_tag_ko
+    then:
+    - rtttl.play: "beep:d=8,o=5,b=100:b"
 
-- service: play_rtttl
-  variables:
-    song_str: string
-  then:
-  - rtttl.play: !lambda 'return song_str;'
+  - service: play_rtttl
+    variables:
+      song_str: string
+    then:
+    - rtttl.play: !lambda 'return song_str;'
 
 # Enable OTA upgrade
 ota:
 
 # Enable SPI interface
 spi:
-clk_pin: D5
-miso_pin: D6
-mosi_pin: D7
+  clk_pin: D0
+  miso_pin: D1
+  mosi_pin: D2
 
 # Configure the PN532 module
 pn532:
-cs_pin: D3
-update_interval: 2s
+  cs_pin: D3
+  update_interval: 2s
 
-# What happens when a tag is read
-on_tag:
-  then:
-  - homeassistant.event:
-      event: esphome.tag_scanned
-      data:
-        tag_id: !lambda 'return x;'
-  - if:
-      condition:
-        switch.is_on: buzzer_enabled
-      then:
-      - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
-  - if:
-      condition:
-        switch.is_on: led_enabled
-      then:
-      - light.turn_on:
-          id: activity_led
-          brightness: 100%
-          red: 0%
-          green: 100%
-          blue: 0%
-          flash_length: 500ms
+  # What happens when a tag is read
+  on_tag:
+    then:
+    - homeassistant.tag_scanned: !lambda 'return x;'
+    - if:
+        condition:
+          switch.is_on: buzzer_enabled
+        then:
+        - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
+    - if:
+        condition:
+          switch.is_on: led_enabled
+        then:
+        - light.turn_on:
+            id: activity_led
+            brightness: 100%
+            red: 0%
+            green: 100%
+            blue: 0%
+            flash_length: 500ms
 
 # Define the buzzer output
 output:
 - platform: esp8266_pwm
-pin: D0
-id: buzzer
+  pin: D8
+  id: buzzer
 
 # Define buzzer as output for RTTTL
 rtttl:
-output: buzzer
+  output: buzzer
 
 # Configure LED
 light:
 - platform: fastled_clockless
-chipset: WS2812
-pin: D2
-default_transition_length: 10ms
-num_leds: 1
-rgb_order: GRB
-id: activity_led
-name: "${friendly_name} LED"
-restore_mode: ALWAYS_OFF
-
+  chipset: WS2812
+  pin: D7
+  default_transition_length: 10ms
+  num_leds: 1
+  rgb_order: GRB
+  id: activity_led
+  name: "${friendly_name} LED"
+  restore_mode: ALWAYS_OFF
+  
 text_sensor:
-
 - platform: custom
-lambda: |-
-  auto my_custom_sensor = new MyCustomTextSensor();
-  App.register_component(my_custom_sensor);
-  return {my_custom_sensor};
-
-text_sensors:
-  name: "My Custom Text Sensor"
-  # update_interval 5s
+  lambda: |-
+    auto my_custom_sensor = new MyCustomTextSensor();
+    App.register_component(my_custom_sensor);
+    return {my_custom_sensor};
+  text_sensors:
+    name: "My Custom Text Sensor"

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -17,8 +17,11 @@ esphome:
   name: $devicename
   platform: ESP8266
   board: d1_mini
-  includes: 
-    - rfidreader/src/test.h
+  includes:
+  - includes/ndef.h
+  libraries:
+  - https://github.com/jesserockz/NDEF.git
+  - https://github.com/jesserockz/PN532.git#esphome
 
 # If buzzer is enabled, notify on api connection success
   on_boot:
@@ -44,7 +47,6 @@ switch:
 
 # Enable logging
 logger:
-  baud_rate: 9600
 
 # Enable Home Assistant API
 api:
@@ -68,40 +70,14 @@ ota:
 
 # Enable SPI interface
 spi:
-  clk_pin: D0
-  miso_pin: D1
-  mosi_pin: D2
-
-# Configure the PN532 module
-pn532:
-  cs_pin: D3
-  update_interval: 2s
-
-  # What happens when a tag is read
-  on_tag:
-    then:
-    - homeassistant.tag_scanned: !lambda 'return x;'
-    - if:
-        condition:
-          switch.is_on: buzzer_enabled
-        then:
-        - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
-    - if:
-        condition:
-          switch.is_on: led_enabled
-        then:
-        - light.turn_on:
-            id: activity_led
-            brightness: 100%
-            red: 0%
-            green: 100%
-            blue: 0%
-            flash_length: 500ms
+  clk_pin: D5
+  miso_pin: D6
+  mosi_pin: D7
 
 # Define the buzzer output
 output:
 - platform: esp8266_pwm
-  pin: D8
+  pin: D3
   id: buzzer
 
 # Define buzzer as output for RTTTL
@@ -112,19 +88,43 @@ rtttl:
 light:
 - platform: fastled_clockless
   chipset: WS2812
-  pin: D7
+  pin: D8
   default_transition_length: 10ms
   num_leds: 1
   rgb_order: GRB
   id: activity_led
   name: "${friendly_name} LED"
   restore_mode: ALWAYS_OFF
-  
+
 text_sensor:
 - platform: custom
   lambda: |-
-    auto my_custom_sensor = new MyCustomTextSensor();
-    App.register_component(my_custom_sensor);
-    return {my_custom_sensor};
+    auto ndef_tag_reader = new NDEFTagReader();
+    App.register_component(ndef_tag_reader);
+    return {ndef_tag_reader};
   text_sensors:
-    name: "My Custom Text Sensor"
+    name: "${friendly_name} Tag"
+    id: scanned_tag
+    on_value:
+      then:
+      - if:
+          condition:
+            lambda: return x != "";
+          then:
+          - homeassistant.tag_scanned: !lambda 'return x;'
+          - if:
+              condition:
+                switch.is_on: buzzer_enabled
+              then:
+              - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
+          - if:
+              condition:
+                switch.is_on: led_enabled
+              then:
+              - light.turn_on:
+                  id: activity_led
+                  brightness: 100%
+                  red: 0%
+                  green: 100%
+                  blue: 0%
+                  flash_length: 500ms

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -1,3 +1,8 @@
+# Insert your SSID and Your PWD after inital setup
+wifi:
+  networks:
+#    - ssid: !secret wifi_ssid          # Uncomment this line (remove # at beginning of line) and enter your details in secrets.yaml file!
+#      password: !secret wifi_password  # Uncomment this line (remove # at beginning of line) and enter your details in secrets.yaml file!
 ap:
   ssid: ${devicename}
 
@@ -119,8 +124,6 @@ name: "${friendly_name} LED"
 restore_mode: ALWAYS_OFF
 
 text_sensor:
-
-
 
 - platform: custom
 lambda: |-


### PR DESCRIPTION
This moves the tag reader to use forked libraries originally from [don/NDEF](https://github.com/don/NDEF) and [seeed-studio/PN532](https://github.com/seeed-studio/PN532) to read the NDEF data on tags.

The SPI has also moved to use the hardware pins which closes #29 