### PR TITLE
Remove `baud_rate` from tagreader.yaml

### DIFF
--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -42,7 +42,6 @@ switch:
 
 # Enable logging
 logger:
-  baud_rate: 9600
 
 # Enable Home Assistant API
 api:


### PR DESCRIPTION
Specifying the `baud_rate` in the code seems to be putting some "clones" (specifically AZDelivery) into a boot loop.
This PR removes it from the config as it is not really needed anyway.