### PR TITLE
Added restore_state to the switches

### DIFF
--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -41,11 +41,13 @@ switch:
   id: buzzer_enabled
   icon: mdi:volume-high
   optimistic: true
+  restore_state: true
 - platform: template
   name: "${friendly_name} LED enabled"
   id: led_enabled
   icon: mdi:alarm-light-outline
   optimistic: true
+  restore_state: true
 
 # Enable logging
 logger:


### PR DESCRIPTION
Added restore_state: true to both the Buzzer switch and the LED switch so the user doesn't have to create an automaton just to keep the visual and audible feedback on.