### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ This enables the PN532 module to communicate with the D1 over I2C, and is requir
 To flash the reader firmware to your D1 Mini you point ESPHome at [tagreader.yaml](tagreader.yaml).  
 > :warning: The tag reader requires the *dev* version of ESPHome until `1.16.0` is released with the `pn532_i2c` component.
 
-~~If you're new to ESPHome, we recommend that you use the [ESPHome Home Assistant add-on](https://esphome.io/guides/getting_started_hassio.html).~~
-The dev version of ESPHome is available after you add the ESPHome add-ons repository (https://github.com/esphome/hassio) to the Home Assistant Supervisor
+If you're new to ESPHome, we recommend that you use the [ESPHome Home Assistant add-on](https://esphome.io/guides/getting_started_hassio.html).
+The dev version of ESPHome is available after you add the ESPHome add-ons repository (https://github.com/esphome/hassio) to the Home Assistant Supervisor or you can simply add `esphome_version: dev` to your addon config
 
 ![Open Case](docs/open-case.jpg)
 


### PR DESCRIPTION
Removing the starting guide to ESPhome is not good for new uers. The warning that dev version is required should be enough. This will also guide the user towards the addon, as opposed to the other methods of running ESPhome.
Also added easier method to run dev version.