### PR TITLE
Use REPLACEME magic value in secrets.yaml

### DIFF
--- a/secrets.yaml
+++ b/secrets.yaml
@@ -1,2 +1,0 @@
-wifi_ssid: 'REPLACEME'  # Enter your WiFi SSID here. Example: `wifi_ssid: your_network_name`
-wifi_password: 'REPLACEME'  # Enter your wifi password here. Example: `wifi_password: abcde123456`

--- a/secrets.yaml
+++ b/secrets.yaml
@@ -1,2 +1,2 @@
-wifi_ssid: # Enter your WiFi SSID here. Example: `wifi_ssid: your_network_name`
-wifi_password: # Enter your wifi password here. Example: `wifi_password: abcde123456`
+wifi_ssid: 'REPLACEME'  # Enter your WiFi SSID here. Example: `wifi_ssid: your_network_name`
+wifi_password: 'REPLACEME'  # Enter your wifi password here. Example: `wifi_password: abcde123456`

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -1,8 +1,8 @@
 # Insert your SSID and Your PWD after inital setup
 wifi:
   networks:
-#    - ssid: !secret wifi_ssid          # Uncomment this line (remove # at beginning of line) and enter your details in secrets.yaml file!
-#      password: !secret wifi_password  # Uncomment this line (remove # at beginning of line) and enter your details in secrets.yaml file!
+#    - ssid: 'REPLACEME'          # Enter your WiFi SSID here. Example: `ssid: 'your_network_name'`
+#      password: 'REPLACEME'      # Enter your wifi password here. Example: `password: 'abcde123456'`
   ap:
     ssid: ${devicename}
 


### PR DESCRIPTION
Hi, awesome work here!

I have a small suggestion for the secrets.yaml file - use 'REPLACEME' as the default value for settings. This is a magic :sparkles: value that makes ESPHome warn the user they need to replace it:

![image](https://user-images.githubusercontent.com/6833237/122108689-c84fa100-ce1c-11eb-926f-642a449888ce.png)

(only appears if `network` section in uncommented in tagreader.yaml)