### PR TITLE
allow playlist in NDEF url

### DIFF
--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -288,8 +288,8 @@ pn532_i2c:
               id(source)="sonos";
               id(url)=payload;
             }
-            else if (type == "T" and id(source)=="sonos" ) {
-              ESP_LOGD("tagreader", "Found Sonos info tag NDEF");
+            else if (type == "T" ) {
+              ESP_LOGD("tagreader", "Found music info tag NDEF");
               id(info)=payload;
             }
             else if ( id(source)=="" ) {

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -213,6 +213,48 @@ pn532_i2c:
   id: pn532_board
   on_tag:
     then:
+
+    - if:
+        condition:
+          lambda: |
+            if (tag.has_ndef_message()) {
+              auto message = tag.get_ndef_message();
+              auto records = message->get_records();
+              for (auto &record : records) {
+                std::string payload = record->get_payload();
+                std::string type = record->get_type();
+                size_t applemusic = payload.find("https://open.spotify.com");
+                size_t spotify = payload.find("https://music.apple.com");
+                if (type == "U" and (
+                  applemusic != std::string::npos or
+                  spotify != std::string::npos
+                )) {
+                  ESP_LOGD("tagreader", "Found music tag NDEF");
+                  return true;
+                }
+              }
+            }
+            return false;
+        then:
+        - homeassistant.event:
+            event: esphome.music_tag
+            data_template:
+              reader: !lambda |
+                return App.get_name().c_str();
+              url: !lambda |
+                auto message = tag.get_ndef_message();
+                auto records = message->get_records();
+                for (auto &record : records) {
+                  std::string payload = record->get_payload();
+                  std::string type = record->get_type();
+                  size_t pos = payload.find("https://");
+                  if (type == "U" and pos != std::string::npos) {
+                    ESP_LOGD("tagreader", "Sending event music_tag");
+                    return payload;
+                  }
+                }
+                return x;
+
     - homeassistant.tag_scanned: !lambda |
         if (!tag.has_ndef_message()) {
           ESP_LOGD("tagreader", "No NDEF");
@@ -227,7 +269,7 @@ pn532_i2c:
             return payload.substr(pos + 34);
           }
         }
-        ESP_LOGD("tagreader", "Bad NDEF, fallback to uid");
+        ESP_LOGD("tagreader", "Not HA NDEF, fallback to uid");
         return x;
     - if:
         condition:

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -209,6 +209,14 @@ i2c:
   scan: False
   frequency: 400kHz
 
+globals:
+  - id: source
+    type: std::string
+  - id: url
+    type: std::string
+  - id: info
+    type: std::string
+
 pn532_i2c:
   id: pn532_board
   on_tag:
@@ -224,69 +232,86 @@ pn532_i2c:
             green: 100%
             blue: 0%
             flash_length: 500ms
-    - if:
-        condition:
-          lambda: |
-            if (tag.has_ndef_message()) {
-              auto message = tag.get_ndef_message();
-              auto records = message->get_records();
-              for (auto &record : records) {
-                std::string payload = record->get_payload();
-                std::string type = record->get_type();
-                size_t applemusic = payload.find("https://open.spotify.com");
-                size_t spotify = payload.find("https://music.apple.com");
-                if (type == "U" and (
-                  applemusic != std::string::npos or
-                  spotify != std::string::npos
-                )) {
-                  ESP_LOGD("tagreader", "Found music tag NDEF");
-                  return true;
-                }
-              }
-            }
-            return false;
-        then:
-        - homeassistant.event:
-            event: esphome.music_tag
-            data_template:
-              reader: !lambda |
-                return App.get_name().c_str();
-              url: !lambda |
-                auto message = tag.get_ndef_message();
-                auto records = message->get_records();
-                for (auto &record : records) {
-                  std::string payload = record->get_payload();
-                  std::string type = record->get_type();
-                  size_t pos = payload.find("https://");
-                  if (type == "U" and pos != std::string::npos) {
-                    ESP_LOGD("tagreader", "Sending event music_tag");
-                    return payload;
-                  }
-                }
-                return x;
-
-    - homeassistant.tag_scanned: !lambda |
-        if (!tag.has_ndef_message()) {
-          ESP_LOGD("tagreader", "No NDEF");
-          return x;
-        }
+    
+    - lambda: |-
+      id(source)="";
+      id(url)="";
+      id(info)="";
+      if (tag.has_ndef_message()) {
         auto message = tag.get_ndef_message();
         auto records = message->get_records();
         for (auto &record : records) {
           std::string payload = record->get_payload();
-          size_t pos = payload.find("https://www.home-assistant.io/tag/");
-          if (pos != std::string::npos) {
-            return payload.substr(pos + 34);
+          std::string type = record->get_type();
+          size_t hass = payload.find("https://www.home-assistant.io/tag/");
+          size_t applemusic = payload.find("https://open.spotify.com");
+          size_t spotify = payload.find("https://music.apple.com");
+          size_t sonos = payload.find("sonos-2://");
+
+          if (type == "U" and ( hass != std::string::npos ) {
+            ESP_LOGD("tagreader", "Found Home Assistant tag NDEF");
+            id(source)="hass";
+            id(url)=payload;
+            id(info)=payload.substr(pos + 34);
+          }
+          else if (type == "U" and ( applemusic != std::string::npos ) {
+            ESP_LOGD("tagreader", "Found Apple Music tag NDEF");
+            id(source)="amusic";
+            id(url)=payload;
+          }
+          else if (type == "U" and ( spotify != std::string::npos ) {
+            ESP_LOGD("tagreader", "Found Spotify tag NDEF");
+            id(source)="spotify";
+            id(url)=payload;
+          }
+          else if (type == "U" and ( sonos != std::string::npos ) {
+            ESP_LOGD("tagreader", "Found Sonos app tag NDEF");
+            id(source)="sonos";
+            id(url)=payload;
+          }
+          else if (type == "T" and id(source)=="sonos" {
+            ESP_LOGD("tagreader", "Found Sonos info tag NDEF");
+            id(info)=payload;
           }
         }
-        ESP_LOGD("tagreader", "Not HA NDEF, fallback to uid");
-        return x;
+      }
+      else {
+        id(source)="uid"
+      }
+    
+    - if:
+      condition:
+        lambda: 'return ( id(source)=="uid" );'
+      then:
+        - homeassistant.tag_scanned: !lambda |-
+          ESP_LOGD("tagreader", "No NDEF");
+          return x;
+      else:
+      - if:
+        condition:
+          lambda: 'return ( id(source)=="hass" )'
+        then:
+        - homeassistant.tag_scanned: !lambda 'return id(info);'
+        else:
+        - homeassistant.event:
+            event: esphome.music_tag
+            data_template:
+              reader: !lambda |-
+                return App.get_name().c_str();
+              source: !lambda |-
+                return id(source);
+              url: !lambda |-
+                return id(url);
+              info: !lambda |-
+                return id(info);
+    
     - if:
         condition:
           switch.is_on: buzzer_enabled
         then:
         - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
-    - delay: 0.1s
+    
+    - delay: 0.11s #to fix slow pn532 component
     
 # Define the buzzer output
 output:

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -317,7 +317,7 @@ pn532_i2c:
             else:
             - homeassistant.event:
                 event: esphome.music_tag
-                data_template:
+                data:
                   reader: !lambda |-
                     return App.get_name().c_str();
                   source: !lambda |-

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -100,11 +100,13 @@ button:
           message->add_uri_record(uri);
           ESP_LOGD("tagreader", "Writing payload: %s", uri.c_str());
           id(pn532_board).write_mode(message);
+      - rtttl.play: "write:d=24,o=5,b=100:b"
       - wait_until:
           not:
             pn532.is_writing:
       - light.turn_off:
           id: activity_led
+      - rtttl.play: "write:d=24,o=5,b=100:b,b"
   - platform: template
     name: Clean Tag
     id: clean_tag
@@ -118,11 +120,13 @@ button:
           green: 64.7%
           blue: 0%    
       - lambda: 'id(pn532_board).clean_mode();'
+      - rtttl.play: "write:d=24,o=5,b=100:b"
       - wait_until:
           not:
             pn532.is_writing:
       - light.turn_off:
-          id: activity_led 
+          id: activity_led
+      - rtttl.play: "write:d=24,o=5,b=100:b,b"
   - platform: template
     name: Cancel writing 
     id: cancel_writing
@@ -130,6 +134,9 @@ button:
     on_press:
       then:
       - lambda: 'id(pn532_board).read_mode();'
+      - light.turn_off:
+          id: activity_led
+      - rtttl.play: "write:d=24,o=5,b=100:b,b"
 
   - platform: restart
     name: "${friendly_name} Restart"
@@ -172,15 +179,18 @@ api:
         uri += tag_id;
         message->add_uri_record(uri);
         id(pn532_board).write_mode(message);
+    - rtttl.play: "write:d=24,o=5,b=100:b"
     - wait_until:
         not:
           pn532.is_writing:
     - light.turn_off:
         id: activity_led
+    - rtttl.play: "write:d=24,o=5,b=100:b,b"
 
   - service: write_music_tag
     variables:
       music_url: string
+      music_info: string
     then:
     - light.turn_on:
         id: activity_led
@@ -191,8 +201,15 @@ api:
     - lambda: |-
         auto message = new nfc::NdefMessage();
         std::string uri = "";
+        std::string text = "";
         uri += music_url;
-        message->add_uri_record(uri);
+        text += music_info;
+        if ( music_url != "" ) {
+          message->add_uri_record(uri);
+        }
+        if ( music_info != "" ) {
+          message->add_text_record(text);
+        }
         id(pn532_board).write_mode(message);
     - rtttl.play: "write:d=24,o=5,b=100:b"
     - wait_until:
@@ -233,6 +250,8 @@ pn532_i2c:
             blue: 0%
             flash_length: 500ms
     
+    - delay: 0.15s #to fix slow component
+        
     - lambda: |-
         id(source)="";
         id(url)="";
@@ -244,39 +263,42 @@ pn532_i2c:
             std::string payload = record->get_payload();
             std::string type = record->get_type();
             size_t hass = payload.find("https://www.home-assistant.io/tag/");
-            size_t applemusic = payload.find("https://open.spotify.com");
-            size_t spotify = payload.find("https://music.apple.com");
+            size_t applemusic = payload.find("https://music.apple.com");
+            size_t spotify = payload.find("https://open.spotify.com");
             size_t sonos = payload.find("sonos-2://");
 
-            if (type == "U" and ( hass != std::string::npos ) {
+            if (type == "U" and hass != std::string::npos ) {
               ESP_LOGD("tagreader", "Found Home Assistant tag NDEF");
               id(source)="hass";
               id(url)=payload;
-              id(info)=payload.substr(pos + 34);
+              id(info)=payload.substr(hass + 34);
             }
-            else if (type == "U" and ( applemusic != std::string::npos ) {
+            else if (type == "U" and applemusic != std::string::npos ) {
               ESP_LOGD("tagreader", "Found Apple Music tag NDEF");
               id(source)="amusic";
               id(url)=payload;
             }
-            else if (type == "U" and ( spotify != std::string::npos ) {
+            else if (type == "U" and spotify != std::string::npos ) {
               ESP_LOGD("tagreader", "Found Spotify tag NDEF");
               id(source)="spotify";
               id(url)=payload;
             }
-            else if (type == "U" and ( sonos != std::string::npos ) {
+            else if (type == "U" and sonos != std::string::npos ) {
               ESP_LOGD("tagreader", "Found Sonos app tag NDEF");
               id(source)="sonos";
               id(url)=payload;
             }
-            else if (type == "T" and id(source)=="sonos" {
+            else if (type == "T" and id(source)=="sonos" ) {
               ESP_LOGD("tagreader", "Found Sonos info tag NDEF");
               id(info)=payload;
+            }
+            else {
+              id(source)="uid";
             }
           }
         }
         else {
-          id(source)="uid"
+          id(source)="uid";
         }
     
     - if:
@@ -284,12 +306,12 @@ pn532_i2c:
           lambda: 'return ( id(source)=="uid" );'
         then:
           - homeassistant.tag_scanned: !lambda |-
-              ESP_LOGD("tagreader", "No NDEF");
+              ESP_LOGD("tagreader", "No HA NDEF, using UID");
               return x;
         else:
         - if:
             condition:
-              lambda: 'return ( id(source)=="hass" )'
+              lambda: 'return ( id(source)=="hass" );'
             then:
             - homeassistant.tag_scanned: !lambda 'return id(info);'
             else:
@@ -355,4 +377,3 @@ light:
   id: activity_led
   name: "${friendly_name} LED"
   restore_mode: ALWAYS_OFF
-  

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -213,7 +213,17 @@ pn532_i2c:
   id: pn532_board
   on_tag:
     then:
-
+    - if:
+        condition:
+          switch.is_on: led_enabled
+        then:
+        - light.turn_on:
+            id: activity_led
+            brightness: 100%
+            red: 0%
+            green: 100%
+            blue: 0%
+            flash_length: 500ms
     - if:
         condition:
           lambda: |
@@ -276,18 +286,8 @@ pn532_i2c:
           switch.is_on: buzzer_enabled
         then:
         - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
-    - if:
-        condition:
-          switch.is_on: led_enabled
-        then:
-        - light.turn_on:
-            id: activity_led
-            brightness: 100%
-            red: 0%
-            green: 100%
-            blue: 0%
-            flash_length: 500ms
-
+    - delay: 0.1s
+    
 # Define the buzzer output
 output:
 - platform: esp8266_pwm

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -234,76 +234,76 @@ pn532_i2c:
             flash_length: 500ms
     
     - lambda: |-
-      id(source)="";
-      id(url)="";
-      id(info)="";
-      if (tag.has_ndef_message()) {
-        auto message = tag.get_ndef_message();
-        auto records = message->get_records();
-        for (auto &record : records) {
-          std::string payload = record->get_payload();
-          std::string type = record->get_type();
-          size_t hass = payload.find("https://www.home-assistant.io/tag/");
-          size_t applemusic = payload.find("https://open.spotify.com");
-          size_t spotify = payload.find("https://music.apple.com");
-          size_t sonos = payload.find("sonos-2://");
+        id(source)="";
+        id(url)="";
+        id(info)="";
+        if (tag.has_ndef_message()) {
+          auto message = tag.get_ndef_message();
+          auto records = message->get_records();
+          for (auto &record : records) {
+            std::string payload = record->get_payload();
+            std::string type = record->get_type();
+            size_t hass = payload.find("https://www.home-assistant.io/tag/");
+            size_t applemusic = payload.find("https://open.spotify.com");
+            size_t spotify = payload.find("https://music.apple.com");
+            size_t sonos = payload.find("sonos-2://");
 
-          if (type == "U" and ( hass != std::string::npos ) {
-            ESP_LOGD("tagreader", "Found Home Assistant tag NDEF");
-            id(source)="hass";
-            id(url)=payload;
-            id(info)=payload.substr(pos + 34);
-          }
-          else if (type == "U" and ( applemusic != std::string::npos ) {
-            ESP_LOGD("tagreader", "Found Apple Music tag NDEF");
-            id(source)="amusic";
-            id(url)=payload;
-          }
-          else if (type == "U" and ( spotify != std::string::npos ) {
-            ESP_LOGD("tagreader", "Found Spotify tag NDEF");
-            id(source)="spotify";
-            id(url)=payload;
-          }
-          else if (type == "U" and ( sonos != std::string::npos ) {
-            ESP_LOGD("tagreader", "Found Sonos app tag NDEF");
-            id(source)="sonos";
-            id(url)=payload;
-          }
-          else if (type == "T" and id(source)=="sonos" {
-            ESP_LOGD("tagreader", "Found Sonos info tag NDEF");
-            id(info)=payload;
+            if (type == "U" and ( hass != std::string::npos ) {
+              ESP_LOGD("tagreader", "Found Home Assistant tag NDEF");
+              id(source)="hass";
+              id(url)=payload;
+              id(info)=payload.substr(pos + 34);
+            }
+            else if (type == "U" and ( applemusic != std::string::npos ) {
+              ESP_LOGD("tagreader", "Found Apple Music tag NDEF");
+              id(source)="amusic";
+              id(url)=payload;
+            }
+            else if (type == "U" and ( spotify != std::string::npos ) {
+              ESP_LOGD("tagreader", "Found Spotify tag NDEF");
+              id(source)="spotify";
+              id(url)=payload;
+            }
+            else if (type == "U" and ( sonos != std::string::npos ) {
+              ESP_LOGD("tagreader", "Found Sonos app tag NDEF");
+              id(source)="sonos";
+              id(url)=payload;
+            }
+            else if (type == "T" and id(source)=="sonos" {
+              ESP_LOGD("tagreader", "Found Sonos info tag NDEF");
+              id(info)=payload;
+            }
           }
         }
-      }
-      else {
-        id(source)="uid"
-      }
+        else {
+          id(source)="uid"
+        }
     
     - if:
-      condition:
-        lambda: 'return ( id(source)=="uid" );'
-      then:
-        - homeassistant.tag_scanned: !lambda |-
-          ESP_LOGD("tagreader", "No NDEF");
-          return x;
-      else:
-      - if:
         condition:
-          lambda: 'return ( id(source)=="hass" )'
+          lambda: 'return ( id(source)=="uid" );'
         then:
-        - homeassistant.tag_scanned: !lambda 'return id(info);'
+          - homeassistant.tag_scanned: !lambda |-
+              ESP_LOGD("tagreader", "No NDEF");
+              return x;
         else:
-        - homeassistant.event:
-            event: esphome.music_tag
-            data_template:
-              reader: !lambda |-
-                return App.get_name().c_str();
-              source: !lambda |-
-                return id(source);
-              url: !lambda |-
-                return id(url);
-              info: !lambda |-
-                return id(info);
+        - if:
+            condition:
+              lambda: 'return ( id(source)=="hass" )'
+            then:
+            - homeassistant.tag_scanned: !lambda 'return id(info);'
+            else:
+            - homeassistant.event:
+                event: esphome.music_tag
+                data_template:
+                  reader: !lambda |-
+                    return App.get_name().c_str();
+                  source: !lambda |-
+                    return id(source);
+                  url: !lambda |-
+                    return id(url);
+                  info: !lambda |-
+                    return id(info);
     
     - if:
         condition:

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -333,8 +333,6 @@ pn532_i2c:
         then:
         - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
     
-    - delay: 0.11s #to fix slow pn532 component
-    
 # Define the buzzer output
 output:
 - platform: esp8266_pwm

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -178,6 +178,29 @@ api:
     - light.turn_off:
         id: activity_led
 
+  - service: write_music_tag
+    variables:
+      music_url: string
+    then:
+    - light.turn_on:
+        id: activity_led
+        brightness: 100%
+        red: 100%
+        green: 0%
+        blue: 0%    
+    - lambda: |-
+        auto message = new nfc::NdefMessage();
+        std::string uri = "";
+        uri += music_url;
+        message->add_uri_record(uri);
+        id(pn532_board).write_mode(message);
+    - rtttl.play: "write:d=24,o=5,b=100:b"
+    - wait_until:
+        not:
+          pn532.is_writing:
+    - light.turn_off:
+        id: activity_led
+    - rtttl.play: "write:d=24,o=5,b=100:b,b"
 
 # Enable OTA upgrade
 ota:

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -292,7 +292,7 @@ pn532_i2c:
               ESP_LOGD("tagreader", "Found Sonos info tag NDEF");
               id(info)=payload;
             }
-            else {
+            else if ( id(source)=="" ) {
               id(source)="uid";
             }
           }


### PR DESCRIPTION
This modification will allow to read Spotify and Apple Music playlist url from NDEF tag and use it in HA incoming as event music_tag. Additionally, there is a write_music_tag service which allow to write any url as NDEF on the tag