### PR TITLE
Add a YouTube and YouTube Music support for music tags

### DIFF
--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -10,7 +10,7 @@ wifi:
 captive_portal:
 
 dashboard_import:
-  package_import_url: github://cheerpipe/tagreader/tagreader.yaml
+  package_import_url: github://adonno/tagreader/tagreader.yaml
 
 improv_serial:
 
@@ -266,6 +266,7 @@ pn532_i2c:
             size_t applemusic = payload.find("https://music.apple.com");
             size_t spotify = payload.find("https://open.spotify.com");
             size_t youtube = payload.find("https://www.youtube.com/");
+            size_t youtubem = payload.find("https://music.youtube.com/");
             size_t sonos = payload.find("sonos-2://");
 
             if (type == "U" and hass != std::string::npos ) {
@@ -288,7 +289,12 @@ pn532_i2c:
               ESP_LOGD("tagreader", "Found Youtube tag NDEF");
               id(source)="youtube";
               id(url)=payload;
-            }            
+            }
+            else if (type == "U" and youtubem != std::string::npos ) {
+              ESP_LOGD("tagreader", "Found Youtube Music tag NDEF");
+              id(source)="youtube music";
+              id(url)=payload;
+            }               
             else if (type == "U" and sonos != std::string::npos ) {
               ESP_LOGD("tagreader", "Found Sonos app tag NDEF");
               id(source)="sonos";

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -32,7 +32,7 @@ esphome:
   # configuration and updates.
   project:
     name: adonno.tag_reader
-    version: "1.4"
+    version: "1.5"
 # If buzzer is enabled, notify on api connection success
   on_boot:
     priority: -10
@@ -223,8 +223,8 @@ api:
 ota:
 
 i2c:
-  scan: False
-  frequency: 400kHz
+  scan: True
+  frequency: 50kHz
 
 globals:
   - id: source
@@ -238,27 +238,16 @@ pn532_i2c:
   id: pn532_board
   on_tag:
     then:
-    - if:
-        condition:
-          switch.is_on: led_enabled
-        then:
-        - light.turn_on:
-            id: activity_led
-            brightness: 100%
-            red: 0%
-            green: 100%
-            blue: 0%
-            flash_length: 500ms
-    
-    - delay: 0.15s #to fix slow component
-        
     - lambda: |-
-        id(source)="";
+        id(source)="unknown";
         id(url)="";
-        id(info)="";
+        ESP_LOGD("tagreader", "Start tag processing");
         if (tag.has_ndef_message()) {
+          ESP_LOGD("tagreader", "Tag is NDEF");
           auto message = tag.get_ndef_message();
+          ESP_LOGD("tagreader", "Tag message readed");
           auto records = message->get_records();
+          ESP_LOGD("tagreader", "Tag records obtained");
           for (auto &record : records) {
             std::string payload = record->get_payload();
             std::string type = record->get_type();
@@ -268,7 +257,7 @@ pn532_i2c:
             size_t youtube = payload.find("https://www.youtube.com/");
             size_t youtubem = payload.find("https://music.youtube.com/");
             size_t sonos = payload.find("sonos-2://");
-
+            ESP_LOGD("tagreader", "Reading payload: %s", payload.c_str());
             if (type == "U" and hass != std::string::npos ) {
               ESP_LOGD("tagreader", "Found Home Assistant tag NDEF");
               id(source)="hass";
@@ -310,9 +299,10 @@ pn532_i2c:
           }
         }
         else {
+          ESP_LOGD("tagreader", "Tag is not NDEF");
           id(source)="uid";
         }
-    
+
     - if:
         condition:
           lambda: 'return ( id(source)=="uid" );'
@@ -338,13 +328,48 @@ pn532_i2c:
                     return id(url);
                   info: !lambda |-
                     return id(info);
-    
+
+    - delay: 0.15s
+
     - if:
         condition:
           switch.is_on: buzzer_enabled
         then:
-        - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
-    
+        - if:
+            condition:
+              lambda: 'return ( id(source)!="uid" );'
+            then:
+            - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
+            else:
+            - rtttl.play: "failure:d=4,o=5,b=100:16e6,16e6"
+
+    - delay: 0.15s
+            
+    - if:
+        condition:
+          switch.is_on: led_enabled
+        then:
+        - if:
+            condition:
+              lambda: 'return ( id(source)!="uid" );'
+            then:
+            - light.turn_on:
+                id: activity_led
+                brightness: 100%
+                red: 0%
+                green: 100%
+                blue: 0%
+                flash_length: 500ms
+            else:
+            - light.turn_on:
+                id: activity_led
+                brightness: 100%
+                red: 100%
+                green: 0%
+                blue: 0%
+                flash_length: 500ms
+
+        
 # Define the buzzer output
 output:
 - platform: esp8266_pwm

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -10,7 +10,7 @@ wifi:
 captive_portal:
 
 dashboard_import:
-  package_import_url: github://adonno/tagreader/tagreader.yaml
+  package_import_url: github://cheerpipe/tagreader/tagreader.yaml
 
 improv_serial:
 

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -265,7 +265,7 @@ pn532_i2c:
             size_t hass = payload.find("https://www.home-assistant.io/tag/");
             size_t applemusic = payload.find("https://music.apple.com");
             size_t spotify = payload.find("https://open.spotify.com");
-            size_t youtube = payload.find("https://https://www.youtube.com/");
+            size_t youtube = payload.find("https://www.youtube.com/");
             size_t sonos = payload.find("sonos-2://");
 
             if (type == "U" and hass != std::string::npos ) {

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -265,6 +265,7 @@ pn532_i2c:
             size_t hass = payload.find("https://www.home-assistant.io/tag/");
             size_t applemusic = payload.find("https://music.apple.com");
             size_t spotify = payload.find("https://open.spotify.com");
+            size_t youtube = payload.find("https://https://www.youtube.com/");
             size_t sonos = payload.find("sonos-2://");
 
             if (type == "U" and hass != std::string::npos ) {
@@ -283,6 +284,11 @@ pn532_i2c:
               id(source)="spotify";
               id(url)=payload;
             }
+            else if (type == "U" and youtube != std::string::npos ) {
+              ESP_LOGD("tagreader", "Found Youtube tag NDEF");
+              id(source)="youtube";
+              id(url)=payload;
+            }            
             else if (type == "U" and sonos != std::string::npos ) {
               ESP_LOGD("tagreader", "Found Sonos app tag NDEF");
               id(source)="sonos";


### PR DESCRIPTION
This is a very simple PR that allows YouTube Links works as music tags.

Working like a charm with Android TV integration 

Next steps: Make an Android TV blueprint.