### PR TITLE
feat: allow turning the beep on boot off

### DIFF
--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -18,6 +18,7 @@ improv_serial:
 substitutions:
   name: tagreader
   friendly_name: TagReader
+  beep_on_boot: true
 
 esphome:
   name: $name
@@ -40,7 +41,11 @@ esphome:
     - wait_until:
         api.connected:
     - logger.log: API is connected!
-    - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
+    - if:
+        condition:
+          lambda: 'return ${beep_on_boot} == true;'
+        then:
+          - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
     - light.turn_on:
         id: activity_led
         brightness: 100%


### PR DESCRIPTION
I'm new to esphome but I'm am trying to prevent the tag reader from beeping when the power goes out.  There is a comment about a condition that seems to have been removed, using the state of the buzzer but that didn't seem to be available when I tried to reference it during startup.  This works and allows me to continue tracking any other updates from this package while overriding it locally with substitutions.

ie
```
substitutions:
  name: "tagreader-playroom"
  friendly_name: "tagreader-playroom"
  beep_on_boot: "false"
```