### PR TITLE
feat: improve button naming uniqueness

### DIFF
--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -71,7 +71,7 @@ switch:
 # Define buttons for writing tags via HA 
 button:
   - platform: template
-    name: Write Tag Random
+    name: "${friendly_name} Write Tag Random"
     id: write_tag_random
     # Optional variables:
     icon: "mdi:pencil-box"
@@ -108,7 +108,7 @@ button:
           id: activity_led
       - rtttl.play: "write:d=24,o=5,b=100:b,b"
   - platform: template
-    name: Clean Tag
+    name: "${friendly_name} Clean Tag"
     id: clean_tag
     icon: "mdi:nfc-variant-off"
     on_press:
@@ -128,7 +128,7 @@ button:
           id: activity_led
       - rtttl.play: "write:d=24,o=5,b=100:b,b"
   - platform: template
-    name: Cancel writing 
+    name: "${friendly_name} Cancel writing"
     id: cancel_writing
     icon: "mdi:pencil-off"
     on_press:


### PR DESCRIPTION
this small change allows the generated entity names to be based on the friendly names like the switches already are.  Without this ha was generating names like 'button.clean_tag_4' since I have more then one which are hard to keep track of