### PR TITLE
feat: Add support for Music Assistant automations using Music Tags

### DIFF
--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -267,6 +267,17 @@ pn532_i2c:
             size_t spotify = payload.find("https://open.spotify.com");
             size_t sonos = payload.find("sonos-2://");
 
+            size_t mass_deezer = payload.find("deezer://");
+            size_t mass_filesystem_local = payload.find("filesystem_local://");
+            size_t mass_filesystem_smb = payload.find("filesystem_smb://");
+            size_t mass_plex = payload.find("plex://");
+            size_t mass_qobuz = payload.find("qobuz://");
+            size_t mass_soundcloud = payload.find("soundcloud://");
+            size_t mass_spotify = payload.find("spotify://");
+            size_t mass_tidal = payload.find("tidal://");
+            size_t mass_tunein = payload.find("tunein://");
+            size_t mass_ytmusic = payload.find("ytmusic://");
+
             if (type == "U" and hass != std::string::npos ) {
               ESP_LOGD("tagreader", "Found Home Assistant tag NDEF");
               id(source)="hass";
@@ -287,6 +298,20 @@ pn532_i2c:
               ESP_LOGD("tagreader", "Found Sonos app tag NDEF");
               id(source)="sonos";
               id(url)=payload;
+            }
+            else if (type == "U" && (mass_deezer != std::string::npos ||
+                    mass_filesystem_local != std::string::npos ||
+                    mass_filesystem_smb != std::string::npos ||
+                    mass_plex != std::string::npos ||
+                    mass_qobuz != std::string::npos ||
+                    mass_soundcloud != std::string::npos ||
+                    mass_spotify != std::string::npos ||
+                    mass_tidal != std::string::npos ||
+                    mass_tunein != std::string::npos ||
+                    mass_ytmusic != std::string::npos)) {
+              ESP_LOGD("tagreader", "Found Music Assistant tag NDEF");
+              id(source) = "mass";
+              id(url) = payload;
             }
             else if (type == "T" ) {
               ESP_LOGD("tagreader", "Found music info tag NDEF");

--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -272,6 +272,7 @@ pn532_i2c:
             size_t mass_filesystem_smb = payload.find("filesystem_smb://");
             size_t mass_plex = payload.find("plex://");
             size_t mass_qobuz = payload.find("qobuz://");
+            size_t mass_radiobrowser = payload.find("radiobrowser://");
             size_t mass_soundcloud = payload.find("soundcloud://");
             size_t mass_spotify = payload.find("spotify://");
             size_t mass_tidal = payload.find("tidal://");
@@ -304,6 +305,7 @@ pn532_i2c:
                     mass_filesystem_smb != std::string::npos ||
                     mass_plex != std::string::npos ||
                     mass_qobuz != std::string::npos ||
+                    mass_radiobrowser != std::string::npos ||
                     mass_soundcloud != std::string::npos ||
                     mass_spotify != std::string::npos ||
                     mass_tidal != std::string::npos ||


### PR DESCRIPTION
In [Music Assistant](https://github.com/music-assistant/hass-music-assistant) the `mass.play_media` service can be used to play music from various services with URIs such as `filesystem_local://track/track01.mp3` or `ytmusic://playlist/xxxxx`

The changes enable to use music tags by using event `id(source) = mass`