### PR TITLE
Migration to new platform config for ESPHome 2025.02

### DIFF
--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -19,10 +19,11 @@ substitutions:
   name: tagreader
   friendly_name: TagReader
 
+esp8266:
+  board: d1_mini
+
 esphome:
   name: $name
-  platform: ESP8266
-  board: d1_mini
 
   # Automatically add the mac address to the name
   # so you can use a single firmware for all devices


### PR DESCRIPTION
Changes for compatibility with ESPHome 2025.02.
<https://esphome.io/components/esp8266>