### PR TITLE
Support ESPHome 2025.8

### DIFF
--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -149,6 +149,7 @@ logger:
 
 # Enable Home Assistant API
 api:
+  homeassistant_services: true
   services:
   - service: rfidreader_tag_ok
     then:


### PR DESCRIPTION
It appears ESPHome introduced a breaking change or something, I can't really find much about it but after a decent amount of searching about this is my fix.

ESPHome 2025.8.0

```
|-- Wire @ 3.2.1 |-- noise-c @ 0.1.10 Compiling .pioenvs/prototype-door-lock/src/main.cpp.o src/main.cpp:42:6: error: 'HomeAssistantServiceCallAction' in namespace 'esphome::api' does not name a template type 42 | api::HomeAssistantServiceCallAction<std::string, nfc::NfcTag> *api_homeassistantservicecallaction_id; | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ src/main.cpp: In function 'void setup()': src/main.cpp:574:3: error: 'api_homeassistantservicecallaction_id' was not declared in this scope 574 | api_homeassistantservicecallaction_id = new api::HomeAssistantServiceCallAction<std::string, nfc::NfcTag>(api_apiserver_id, true); | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ src/main.cpp:574:52: error: 'HomeAssistantServiceCallAction' in namespace 'esphome::api' does not name a template type 574 | api_homeassistantservicecallaction_id = new api::HomeAssistantServiceCallAction<std::string, nfc::NfcTag>(api_apiserver_id, true); | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ src/main.cpp:574:94: error: expected primary-expression before ',' token 574 | api_homeassistantservicecallaction_id = new api::HomeAssistantServiceCallAction<std::string, nfc::NfcTag>(api_apiserver_id, true); | ^ src/main.cpp:574:107: error: expected primary-expression before '>' token 574 | api_homeassistantservicecallaction_id = new api::HomeAssistantServiceCallAction<std::string, nfc::NfcTag>(api_apiserver_id, true); | ^ /config/esphome/test.yaml:209:31: error: cannot convert '<brace-enclosed initializer list>' to 'const std::vector<esphome::Action<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, esphome::nfc::NfcTag>*, std::allocator<esphome::Action<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, esphome::nfc::NfcTag>*> >&' 209 | - platform: template | ~~~~~~~~~~~~~~~~~~~~ ^ In file included from src/esphome/components/binary_sensor/filter.h:3, from src/esphome/components/binary_sensor/binary_sensor.h:5, from src/esphome/core/application.h:26, from src/esphome/components/api/api_frame_helper.h:12, from src/esphome/components/api/api_connection.h:5, from src/esphome.h:3, from src/main.cpp:3: src/esphome/core/automation.h:289:56: note: initializing argument 1 of 'void esphome::Automation<Ts>::add_actions(const std::vector<esphome::Action<Ts ...>*>&) [with Ts = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, esphome::nfc::NfcTag}]' 289 | void add_actions(const std::vector<Action<Ts...> *> &actions) { this->actions_.add_actions(actions); } | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~ *** [.pioenvs/prototype-door-lock/src/main.cpp.o] Error 1
```

STR: Try compile w/ ESPHome Builder 2025.8 - will not compile.  Add line to api: - will compile.