### PR TITLE
Update RTTTL durations in tagreader.yamlFix rttl d=24 issue

### DIFF
--- a/tagreader.yaml
+++ b/tagreader.yaml
@@ -41,7 +41,7 @@ esphome:
     - wait_until:
         api.connected:
     - logger.log: API is connected!
-    - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
+    - rtttl.play: "success:d=16,o=5,b=100:c,g,b"
     - light.turn_on:
         id: activity_led
         brightness: 100%
@@ -101,13 +101,13 @@ button:
           message->add_uri_record(uri);
           ESP_LOGD("tagreader", "Writing payload: %s", uri.c_str());
           id(pn532_board).write_mode(message);
-      - rtttl.play: "write:d=24,o=5,b=100:b"
+      - rtttl.play: "write:d=16,o=5,b=100:b"
       - wait_until:
           not:
             pn532.is_writing:
       - light.turn_off:
           id: activity_led
-      - rtttl.play: "write:d=24,o=5,b=100:b,b"
+      - rtttl.play: "write:d=16,o=5,b=100:b,b"
   - platform: template
     name: Clean Tag
     id: clean_tag
@@ -121,13 +121,13 @@ button:
           green: 64.7%
           blue: 0%
       - lambda: 'id(pn532_board).clean_mode();'
-      - rtttl.play: "write:d=24,o=5,b=100:b"
+      - rtttl.play: "write:d=16,o=5,b=100:b"
       - wait_until:
           not:
             pn532.is_writing:
       - light.turn_off:
           id: activity_led
-      - rtttl.play: "write:d=24,o=5,b=100:b,b"
+      - rtttl.play: "write:d=16,o=5,b=100:b,b"
   - platform: template
     name: Cancel writing
     id: cancel_writing
@@ -137,7 +137,7 @@ button:
       - lambda: 'id(pn532_board).read_mode();'
       - light.turn_off:
           id: activity_led
-      - rtttl.play: "write:d=24,o=5,b=100:b,b"
+      - rtttl.play: "write:d=16,o=5,b=100:b,b"
 
   - platform: restart
     name: "${friendly_name} Restart"
@@ -180,13 +180,13 @@ api:
         uri += tag_id;
         message->add_uri_record(uri);
         id(pn532_board).write_mode(message);
-    - rtttl.play: "write:d=24,o=5,b=100:b"
+    - rtttl.play: "write:d=16,o=5,b=100:b"
     - wait_until:
         not:
           pn532.is_writing:
     - light.turn_off:
         id: activity_led
-    - rtttl.play: "write:d=24,o=5,b=100:b,b"
+    - rtttl.play: "write:d=16,o=5,b=100:b,b"
 
   - service: write_music_tag
     variables:
@@ -212,13 +212,13 @@ api:
           message->add_text_record(text);
         }
         id(pn532_board).write_mode(message);
-    - rtttl.play: "write:d=24,o=5,b=100:b"
+    - rtttl.play: "write:d=16,o=5,b=100:b"
     - wait_until:
         not:
           pn532.is_writing:
     - light.turn_off:
         id: activity_led
-    - rtttl.play: "write:d=24,o=5,b=100:b,b"
+    - rtttl.play: "write:d=16,o=5,b=100:b,b"
 
 # Enable OTA upgrade
 ota:
@@ -360,7 +360,7 @@ pn532_i2c:
         condition:
           switch.is_on: buzzer_enabled
         then:
-        - rtttl.play: "success:d=24,o=5,b=100:c,g,b"
+        - rtttl.play: "success:d=16,o=5,b=100:c,g,b"
   on_tag_removed:
     then:
     - homeassistant.event:


### PR DESCRIPTION
Tagreader doesn't play sound on ESPHOME 2026.3.0 as d=24 is not a valid rtttl duration. Changed to d=16